### PR TITLE
Enable creation of new bookmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ checksum = "a41603f7cdbf5ac4af60760f17253eb6adf6ec5b6f14a7ed830cf687d375f163"
 dependencies = [
  "askama",
  "axum-core 0.4.3",
- "http 1.0.0",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -307,7 +307,7 @@ dependencies = [
  "axum-macros",
  "bytes",
  "futures-util",
- "http 1.0.0",
+ "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.2.0",
@@ -357,7 +357,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.0.0",
+ "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
  "mime",
@@ -379,7 +379,7 @@ dependencies = [
  "axum-core 0.4.3",
  "bytes",
  "futures-util",
- "http 1.0.0",
+ "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
  "mime",
@@ -416,7 +416,7 @@ dependencies = [
  "axum 0.7.4",
  "bytes",
  "cookie",
- "http 1.0.0",
+ "http 1.1.0",
  "http-body-util",
  "hyper 1.2.0",
  "hyper-util",
@@ -948,6 +948,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,7 +1173,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 1.0.0",
+ "http 1.1.0",
  "indexmap 2.2.3",
  "slab",
  "tokio",
@@ -1266,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -1293,7 +1308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
- "http 1.0.0",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -1304,7 +1319,7 @@ checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.0.0",
+ "http 1.1.0",
  "http-body 1.0.0",
  "pin-project-lite",
 ]
@@ -1376,7 +1391,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2 0.4.2",
- "http 1.0.0",
+ "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
  "httpdate",
@@ -1400,6 +1415,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.28",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,7 +1436,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.0.0",
+ "http 1.1.0",
  "http-body 1.0.0",
  "hyper 1.2.0",
  "pin-project-lite",
@@ -1607,8 +1635,6 @@ dependencies = [
  "clap",
  "lz-db",
  "lz-web",
- "reqwest",
- "scraper",
  "sqlx",
  "tokio",
  "url",
@@ -1682,12 +1708,15 @@ dependencies = [
  "axum-valid",
  "chrono",
  "clap",
+ "lazy_static",
  "lz-db",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "prettyplease",
  "progenitor",
+ "reqwest",
+ "scraper",
  "serde",
  "serde_json",
  "sqlx",
@@ -1851,6 +1880,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,6 +2021,50 @@ dependencies = [
  "indexmap 2.2.3",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2530,19 +2621,23 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-util",
  "tower-service",
  "url",
@@ -2653,6 +2748,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2671,6 +2775,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2719,6 +2832,29 @@ dependencies = [
  "once_cell",
  "selectors",
  "tendril",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3439,6 +3575,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3560,7 +3706,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.0.0",
+ "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
  "http-range-header 0.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,6 +764,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate-display"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98a85201f233142ac819bbf6226e36d0b5e129a47bd325084674261c82d4cd66"
+dependencies = [
+ "macroific",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,6 +1620,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "delegate-display",
  "indoc",
  "once_cell",
  "serde",
@@ -1702,6 +1715,53 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "macroific"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05c00ac596022625d01047c421a0d97d7f09a18e429187b341c201cb631b9dd"
+dependencies = [
+ "macroific_attr_parse",
+ "macroific_core",
+ "macroific_macro",
+]
+
+[[package]]
+name = "macroific_attr_parse"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd94d5da95b30ae6e10621ad02340909346ad91661f3f8c0f2b62345e46a2f67"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "macroific_core"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13198c120864097a565ccb3ff947672d969932b7975ebd4085732c9f09435e55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "macroific_macro"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c9853143cbed7f1e41dc39fee95f9b361bec65c8dc2a01bf609be01b61f5ae"
+dependencies = [
+ "macroific_attr_parse",
+ "macroific_core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
 
 [[package]]
 name = "markup5ever"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,20 +57,11 @@ utoipa-redoc = "3.0.0"
 utoipa-swagger-ui = "6.0.0"
 validator = "=0.16.1"
 bytes = "1.4.0"
-console_error_panic_hook = "0.1.7"
-dioxus = "0.5"
-dioxus-logger = "0.4.1"
 futures-core = "0.3.28"
-log = "0.4.19"
 percent-encoding = "2.3.0"
 serde_urlencoded = "0.7.1"
-tracing-wasm = "0.2.1"
 axum-extra = "0.9.3"
-web-sys = "0.3.69"
 askama = "0.12.1"
 askama_axum = "0.4.0"
 axum-test = "14.8.0"
-
-# From https://djc.github.io/askama/performance.html:
-[profile.dev.package.askama_derive]
-opt-level = 3
+delegate-display = "2.1.1"

--- a/src/lz-cli/Cargo.toml
+++ b/src/lz-cli/Cargo.toml
@@ -11,10 +11,8 @@ dev = ["lz-web/dev"]
 
 [dependencies]
 anyhow = { workspace = true }
-chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-reqwest = { workspace = true }
-scraper = { workspace = true }
+chrono = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }

--- a/src/lz-cli/src/main.rs
+++ b/src/lz-cli/src/main.rs
@@ -4,7 +4,9 @@ use std::str::FromStr;
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Local, LocalResult, NaiveDateTime, TimeZone, Utc};
 use clap::{Parser, Subcommand};
-use lz_db::{Bookmark, BookmarkId, BookmarkSearch, Connection, DateInput, ReadOnly, Transaction};
+use lz_db::{
+    Bookmark, BookmarkId, BookmarkSearch, Connection, DateInput, NoId, ReadOnly, Transaction,
+};
 use scraper::{Html, Selector};
 use url::Url;
 
@@ -264,7 +266,7 @@ async fn add_link(
     }
 }
 
-async fn lookup_link_from_web(link: &String) -> Result<Bookmark<(), ()>> {
+async fn lookup_link_from_web(link: &String) -> Result<Bookmark<NoId, NoId>> {
     // This currently assumes all lookups are against HTML pages, which is a
     // reasonable starting point but would prevent e.g. bookmarking images.
     let now = Utc::now();
@@ -293,7 +295,7 @@ async fn lookup_link_from_web(link: &String) -> Result<Bookmark<(), ()>> {
         accessed_at: Some(now),
         created_at: now,
         description: description.clone(),
-        id: (),
+        id: NoId,
         import_properties: None,
         modified_at: None,
         notes: None,
@@ -301,7 +303,7 @@ async fn lookup_link_from_web(link: &String) -> Result<Bookmark<(), ()>> {
         title: title.clone(),
         unread: true,
         url,
-        user_id: (),
+        user_id: NoId,
         website_title: if title.as_str() == "" {
             None
         } else {

--- a/src/lz-db/Cargo.toml
+++ b/src/lz-db/Cargo.toml
@@ -17,6 +17,7 @@ sqlx = { workspace = true, features = ["sqlite", "migrate", "runtime-tokio", "js
 serde_json = { workspace = true, features = ["raw_value"] }
 chrono = { workspace = true, features = ["serde"] }
 utoipa = { workspace = true, features = ["chrono", "url"] }
+delegate-display = { workspace = true }
 
 [dev-dependencies]
 test-context = { workspace = true }

--- a/src/lz-db/src/transaction.rs
+++ b/src/lz-db/src/transaction.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Deserializer, Serialize};
+use std::fmt;
 use std::marker::PhantomData;
 
 use crate::Connection;
@@ -118,7 +119,7 @@ impl<M: TransactionMode> Transaction<M> {
     }
 }
 
-pub trait IdType<T>: Copy {
+pub trait IdType<T>: Copy + fmt::Display {
     type Id;
 
     /// Returns the inner ID.
@@ -163,6 +164,13 @@ impl<T> IdType<T> for NoId {
 
     fn id(self) -> Self::Id {
         unreachable!("You mustn't try to access non-IDs.");
+    }
+}
+
+/// The NoId type renders to strings as `"new"`.
+impl fmt::Display for NoId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "new")
     }
 }
 

--- a/src/lz-db/src/transaction/bookmark.rs
+++ b/src/lz-db/src/transaction/bookmark.rs
@@ -4,7 +4,7 @@ use sqlx::query_scalar;
 use url::Url;
 use utoipa::{ToResponse, ToSchema};
 
-use crate::{IdType, ReadWrite, Transaction, TransactionMode, UserId};
+use crate::{IdType, NoId, ReadWrite, Transaction, TransactionMode, UserId};
 
 /// The database ID of a bookmark.
 #[derive(
@@ -110,7 +110,10 @@ impl<U: IdType<UserId>> From<Bookmark<BookmarkId, U>> for BookmarkId {
 impl Transaction<ReadWrite> {
     /// Store a new bookmark in the database.
     #[tracing::instrument(skip(self))]
-    pub async fn add_bookmark(&mut self, bm: Bookmark<(), ()>) -> Result<BookmarkId, sqlx::Error> {
+    pub async fn add_bookmark(
+        &mut self,
+        bm: Bookmark<NoId, NoId>,
+    ) -> Result<BookmarkId, sqlx::Error> {
         let user_id = self.user().id;
         let url_id = self.ensure_url(&bm.url).await?;
         let id = query_scalar!(

--- a/src/lz-db/src/transaction/bookmark.rs
+++ b/src/lz-db/src/transaction/bookmark.rs
@@ -19,6 +19,7 @@ use crate::{IdType, NoId, ReadWrite, Transaction, TransactionMode, UserId};
     sqlx::Type,
     ToSchema,
     ToResponse,
+    delegate_display::DelegateDisplay,
 )]
 #[sqlx(transparent)]
 #[serde(transparent)]

--- a/src/lz-db/src/transaction/tag.rs
+++ b/src/lz-db/src/transaction/tag.rs
@@ -20,6 +20,7 @@ use crate::{BookmarkId, IdType, ReadWrite, Transaction, TransactionMode};
     sqlx::Type,
     ToSchema,
     ToResponse,
+    delegate_display::DelegateDisplay,
 )]
 #[sqlx(transparent)]
 pub struct TagId(i64);

--- a/src/lz-db/src/transaction/url.rs
+++ b/src/lz-db/src/transaction/url.rs
@@ -26,6 +26,7 @@ use crate::{BookmarkId, IdType, ReadWrite, Transaction, TransactionMode};
     sqlx::Type,
     ToSchema,
     ToResponse,
+    delegate_display::DelegateDisplay,
 )]
 #[sqlx(transparent)]
 pub struct StoredUrlId(i64);

--- a/src/lz-db/src/transaction/user.rs
+++ b/src/lz-db/src/transaction/user.rs
@@ -25,6 +25,7 @@ use crate::{IdType, Transaction, TransactionMode};
     sqlx::Type,
     ToSchema,
     ToResponse,
+    delegate_display::DelegateDisplay,
 )]
 #[sqlx(transparent)]
 #[serde(transparent)]

--- a/src/lz-web/Cargo.toml
+++ b/src/lz-web/Cargo.toml
@@ -36,14 +36,16 @@ opentelemetry-otlp = { workspace = true, features = ["trace", "logs", "metrics",
 url = { workspace = true, features = ["serde"] }
 tonic = { workspace = true }
 tonic-web = { workspace = true }
-
-# Deps for generating the rust client:
+reqwest = { workspace = true, features = ["default-tls"] }
+scraper = { workspace = true }
+chrono = { workspace = true }
 progenitor = { workspace = true, optional = true }
 syn = { workspace = true, optional = true }
 prettyplease = { workspace = true, optional = true }
 axum-extra = { workspace = true, features = ["query"] }
 askama_axum = { workspace = true }
 askama = { workspace = true, features = ["with-axum", "serde"] }
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 axum-test = { workspace = true }

--- a/src/lz-web/src/http.rs
+++ b/src/lz-web/src/http.rs
@@ -1,0 +1,68 @@
+//! Functions for interacting with websites that we want to bookmark.
+
+use chrono::Utc;
+use lazy_static::lazy_static;
+use lz_db::{Bookmark, NoId};
+use scraper::{Html, Selector};
+use url::Url;
+
+/// Errors that can occur when retrieving content from the web
+#[derive(thiserror::Error, Debug)]
+pub enum LookupError {
+    #[error("could not retrieve link")]
+    HttpError(#[from] reqwest::Error),
+}
+
+fn make_selector(selector: &str) -> Selector {
+    Selector::parse(selector).unwrap()
+}
+
+lazy_static! {
+    static ref TITLE: Selector = make_selector("title");
+    static ref DESCRIPTION: Selector = make_selector(r#"meta[name="description"]"#);
+}
+
+pub async fn lookup_link_from_web(url: &Url) -> Result<Bookmark<NoId, NoId>, LookupError> {
+    // This currently assumes all lookups are against HTML pages, which is a
+    // reasonable starting point but would prevent e.g. bookmarking images.
+    let now = Utc::now();
+    let response = reqwest::get(url.clone()).await?;
+    response.error_for_status_ref()?;
+    let body = response.text().await?;
+    let doc = Html::parse_document(&body);
+    let root_ref = doc.root_element();
+    let found_title = root_ref.select(&TITLE).next();
+    let title = match found_title {
+        Some(el) => el.inner_html(),
+        None => "".to_string(),
+    };
+    let found_description = root_ref.select(&DESCRIPTION).next();
+    let description = match found_description {
+        Some(el) => el
+            .value()
+            .attr("content")
+            .map(|meta_val| meta_val.to_string()),
+        None => None,
+    };
+    let to_add = Bookmark {
+        accessed_at: Some(now),
+        created_at: now,
+        description: description.clone(),
+        id: NoId,
+        import_properties: None,
+        modified_at: None,
+        notes: None,
+        shared: true,
+        title: title.clone(),
+        unread: true,
+        url: url.clone(),
+        user_id: NoId,
+        website_title: if title.as_str() == "" {
+            None
+        } else {
+            Some(title.clone())
+        },
+        website_description: description.clone(),
+    };
+    Ok(to_add)
+}

--- a/src/lz-web/src/lib.rs
+++ b/src/lz-web/src/lib.rs
@@ -15,6 +15,7 @@ use utoipa_swagger_ui::SwaggerUi;
 
 pub mod api;
 pub mod db;
+pub mod http;
 pub mod ui;
 
 pub mod export_openapi;

--- a/src/lz-web/src/ui.rs
+++ b/src/lz-web/src/ui.rs
@@ -54,6 +54,7 @@ async fn my_bookmarks(
 
 #[derive(Template)]
 #[template(path = "bookmark_edit_form.html", ext = "html")]
+#[allow(dead_code)] // TODO: show them for adding/editing
 struct BookmarkEditForm<ID: IdType<BookmarkId>, UID: IdType<UserId>> {
     bookmark: Bookmark<ID, UID>,
     tags: Vec<ExistingTag>,

--- a/src/lz-web/src/ui.rs
+++ b/src/lz-web/src/ui.rs
@@ -23,7 +23,7 @@ pub fn router() -> Router<Arc<GlobalWebAppState>> {
     Router::new()
         .route("/", get(my_bookmarks))
         .route("/edit", get(bookmark_edit_form))
-        .route("/edit", post(bookmark_save))
+        .route("/edit", post(bookmark_update))
         .layer(CorsLayer::permissive())
 }
 
@@ -92,7 +92,7 @@ struct BookmarkItem {
 }
 
 #[tracing::instrument()]
-async fn bookmark_save(
+async fn bookmark_update(
     mut txn: DbTransaction<ReadWrite>,
     htmz: HtmzMode,
     Form(data): Form<Bookmark<BookmarkId, UserId>>,

--- a/src/lz-web/src/ui.rs
+++ b/src/lz-web/src/ui.rs
@@ -6,10 +6,10 @@ use askama_axum::Template;
 use axum::extract::Query;
 use axum::routing::{get, post};
 use axum::{Form, Router};
-use lz_db::{Bookmark, BookmarkId, UserId};
-use lz_db::{IdType as _, ReadWrite};
+use lz_db::{AssociatedLink, Bookmark, BookmarkId, ExistingTag, IdType, NoId, ReadWrite, UserId};
 use serde::{Deserialize, Serialize};
 use tower_http::cors::CorsLayer;
+use url::Url;
 
 use crate::db::queries::{
     annotate_bookmarks, list_bookmarks, AnnotatedBookmark, ListResult, Pagination,
@@ -24,6 +24,7 @@ pub fn router() -> Router<Arc<GlobalWebAppState>> {
         .route("/", get(my_bookmarks))
         .route("/edit", get(bookmark_edit_form))
         .route("/edit", post(bookmark_update))
+        .route("/new", get(bookmark_create_form))
         .layer(CorsLayer::permissive())
 }
 
@@ -53,8 +54,30 @@ async fn my_bookmarks(
 
 #[derive(Template)]
 #[template(path = "bookmark_edit_form.html", ext = "html")]
-struct BookmarkEditForm {
-    item: AnnotatedBookmark,
+struct BookmarkEditForm<ID: IdType<BookmarkId>, UID: IdType<UserId>> {
+    bookmark: Bookmark<ID, UID>,
+    tags: Vec<ExistingTag>,
+    associations: Vec<AssociatedLink>,
+}
+
+impl From<AnnotatedBookmark> for BookmarkEditForm<BookmarkId, UserId> {
+    fn from(value: AnnotatedBookmark) -> Self {
+        Self {
+            bookmark: value.bookmark,
+            tags: value.tags,
+            associations: value.associations,
+        }
+    }
+}
+
+impl From<Bookmark<NoId, NoId>> for BookmarkEditForm<NoId, NoId> {
+    fn from(value: Bookmark<NoId, NoId>) -> Self {
+        Self {
+            bookmark: value,
+            tags: vec![],
+            associations: vec![],
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
@@ -67,7 +90,7 @@ async fn bookmark_edit_form(
     mut txn: DbTransaction,
     Query(BookmarkEditFormParams { id }): Query<BookmarkEditFormParams>,
     htmz: HtmzMode,
-) -> Result<HtmzTemplate<BookmarkEditForm>, ()> {
+) -> Result<HtmzTemplate<BookmarkEditForm<BookmarkId, UserId>>, ()> {
     let bm = txn.get_bookmark_by_id(id.id()).await.map_err(|error| {
         tracing::error!(?error, %error, "Could not get bookmark");
     })?;
@@ -80,9 +103,50 @@ async fn bookmark_edit_form(
     Ok(htmz
         .build()
         .title(format!("Editing bookmark {:?}", id))
-        .wrap(BookmarkEditForm {
-            item: annotated.remove(0),
-        }))
+        .wrap(annotated.remove(0).into()))
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+struct BookmarkCreateFormParams {
+    url: Url,
+}
+
+#[tracing::instrument()]
+async fn bookmark_create_form(
+    mut txn: DbTransaction,
+    Query(BookmarkCreateFormParams { url }): Query<BookmarkCreateFormParams>,
+    htmz: HtmzMode,
+) -> Result<axum::response::Response, ()> {
+    if let Some(existing) = txn.find_bookmark_with_url(&url).await.map_err(|error| {
+        tracing::error!(?error, %error, "could not query for existing bookmark");
+    })? {
+        let (mut annotated, _) =
+            annotate_bookmarks(&mut txn, &[existing], 1)
+                .await
+                .map_err(|error| {
+                    tracing::error!(?error, %error, %url, "could not annotate existing bookmark");
+                })?;
+        Ok(askama_axum::into_response(
+            &htmz
+                .build()
+                .title(format!("Editing bookmark with URL {:?}", url))
+                .wrap(BookmarkEditForm::<BookmarkId, UserId>::from(
+                    annotated.remove(0),
+                )),
+        ))
+    } else {
+        let new_bookmark = crate::http::lookup_link_from_web(&url)
+            .await
+            .map_err(|error| {
+                tracing::error!(?error, %error, %url, "could not retrieve url");
+            })?;
+        Ok(askama_axum::into_response(
+            &htmz
+                .build()
+                .title(format!("Adding new bookmark for {}", url))
+                .wrap(BookmarkEditForm::from(new_bookmark)),
+        ))
+    }
 }
 
 #[derive(Debug, Serialize, Template)]

--- a/src/lz-web/templates/bookmark_edit_form.html
+++ b/src/lz-web/templates/bookmark_edit_form.html
@@ -1,14 +1,14 @@
 <html>
   <body>
     <form method="post"
-          id="bookmark-{{- item.bookmark.id.id() -}}"
-          action="#bookmark-{{- item.bookmark.id.id() -}}"
+          id="bookmark-{{- item.bookmark.id -}}"
+          action="#bookmark-{{- item.bookmark.id -}}"
           target="htmz">
       <section>
-        <input name="id" type="hidden" value="{{- item.bookmark.id.id() -}}">
+        <input name="id" type="hidden" value="{{- item.bookmark.id -}}">
         <input name="user_id"
                type="hidden"
-               value="{{- item.bookmark.user_id.id() -}}">
+               value="{{- item.bookmark.user_id -}}">
         <input name="created_at"
                type="hidden"
                value="{{- item.bookmark.created_at -}}">

--- a/src/lz-web/templates/bookmark_edit_form.html
+++ b/src/lz-web/templates/bookmark_edit_form.html
@@ -5,19 +5,41 @@
           action="#bookmark-{{- bookmark.id -}}"
           target="htmz">
       <section>
+        <!-- Hidden IDs/fields: -->
         <input name="id" type="hidden" value="{{- bookmark.id -}}">
-        <input name="user_id"
-               type="hidden"
-               value="{{- bookmark.user_id -}}">
-        <input name="created_at"
-               type="hidden"
-               value="{{- bookmark.created_at -}}">
+        <input name="user_id" type="hidden" value="{{- bookmark.user_id -}}">
+        <input name="created_at" type="hidden" value="{{- bookmark.created_at -}}">
         <input name="shared" type="hidden" value="{{- bookmark.shared -}}">
-        <input name="url" value="{{- bookmark.url -}}">
-        <input name="title" value="{{- bookmark.title -}}">
-        <textarea name="description">{{- bookmark.description.as_deref().unwrap_or(bookmark.website_description.as_deref().unwrap_or("")) -}}</textarea>
-        <textarea name="notes">{{- bookmark.notes.as_deref().unwrap_or("") -}}</textarea>
-        <input name="unread" type="checkbox" value="true" {{- bookmark.unread.then_some("checked").unwrap_or("") -}}>
+        <!-- actual inputs: -->
+        <p>
+          <label for="bookmark-url">URL</label>
+          <input id="bookmark-url"
+                 type="url"
+                 name="url"
+                 size="90"
+                 value="{{- bookmark.url -}}"
+                 required>
+        </p>
+        <p>
+          <label for="bookmark-title">Title</label>
+          <input id="bookmark-title"
+                 name="title"
+                 size="90"
+                 value="{{- bookmark.title -}}"
+                 required>
+        </p>
+        <p>
+          <label for="bookmark-description">Description</label>
+          <textarea id="bookmark-description" cols="80" rows="10" name="description">{{- bookmark.description.as_deref().unwrap_or(bookmark.website_description.as_deref().unwrap_or("")) -}}</textarea>
+        </p>
+        <p>
+          <label for="bookmark-notes">Notes</label>
+          <textarea id="bookmark-notes" cols="80" rows="10" name="notes">{{- bookmark.notes.as_deref().unwrap_or("") -}}</textarea>
+        </p>
+        <p>
+          <label for="bookmark-unread">Unread</label>
+          <input id="bookmark-unread" name="unread" type="checkbox" value="true" {{- bookmark.unread.then_some("checked").unwrap_or("") -}}>
+        </p>
         <input type="submit" value="Save">
       </section>
     </form>

--- a/src/lz-web/templates/bookmark_edit_form.html
+++ b/src/lz-web/templates/bookmark_edit_form.html
@@ -1,23 +1,23 @@
 <html>
   <body>
     <form method="post"
-          id="bookmark-{{- item.bookmark.id -}}"
-          action="#bookmark-{{- item.bookmark.id -}}"
+          id="bookmark-{{- bookmark.id -}}"
+          action="#bookmark-{{- bookmark.id -}}"
           target="htmz">
       <section>
-        <input name="id" type="hidden" value="{{- item.bookmark.id -}}">
+        <input name="id" type="hidden" value="{{- bookmark.id -}}">
         <input name="user_id"
                type="hidden"
-               value="{{- item.bookmark.user_id -}}">
+               value="{{- bookmark.user_id -}}">
         <input name="created_at"
                type="hidden"
-               value="{{- item.bookmark.created_at -}}">
-        <input name="shared" type="hidden" value="{{- item.bookmark.shared -}}">
-        <input name="url" value="{{- item.bookmark.url -}}">
-        <input name="title" value="{{- item.bookmark.title -}}">
-        <textarea name="description">{{- item.bookmark.description.as_deref().unwrap_or(item.bookmark.website_description.as_deref().unwrap_or("")) -}}</textarea>
-        <textarea name="notes">{{- item.bookmark.notes.as_deref().unwrap_or("") -}}</textarea>
-        <input name="unread" type="checkbox" value="true" {{- item.bookmark.unread.then_some("checked").unwrap_or("") -}}>
+               value="{{- bookmark.created_at -}}">
+        <input name="shared" type="hidden" value="{{- bookmark.shared -}}">
+        <input name="url" value="{{- bookmark.url -}}">
+        <input name="title" value="{{- bookmark.title -}}">
+        <textarea name="description">{{- bookmark.description.as_deref().unwrap_or(bookmark.website_description.as_deref().unwrap_or("")) -}}</textarea>
+        <textarea name="notes">{{- bookmark.notes.as_deref().unwrap_or("") -}}</textarea>
+        <input name="unread" type="checkbox" value="true" {{- bookmark.unread.then_some("checked").unwrap_or("") -}}>
         <input type="submit" value="Save">
       </section>
     </form>

--- a/src/lz-web/templates/my_bookmarks.html
+++ b/src/lz-web/templates/my_bookmarks.html
@@ -1,4 +1,10 @@
-<div "">
+    <div id="add-new">
+      <form method="get" action="/new">
+        <label for="new-url-entry">Add URL:</label>
+        <input type="text" name="url" id="new-url-entry">
+      </form>
+    </div>
+<div id="my-bookmarks">
   {% for item in batch %}
     {% include "partials/bookmark_item.html" %}
   {% endfor %}

--- a/src/lz-web/templates/my_bookmarks.html
+++ b/src/lz-web/templates/my_bookmarks.html
@@ -3,7 +3,7 @@
     {% include "partials/bookmark_item.html" %}
   {% endfor %}
   {% match next_cursor %}
-    {% when Some(id) %}<a id="load-more" target="htmz" href="?cursor={{ id.id() }}#load-more">Next page</a>
+    {% when Some(id) %}<a id="load-more" target="htmz" href="?cursor={{ id }}#load-more">Next page</a>
     {% when None %}
   {% endmatch %}
 </div>

--- a/src/lz-web/templates/partials/bookmark_item.html
+++ b/src/lz-web/templates/partials/bookmark_item.html
@@ -1,4 +1,4 @@
-<article id="bookmark-{{ item.bookmark.id.id() }}">
+<article id="bookmark-{{ item.bookmark.id }}">
   <div>{{ item.bookmark.created_at }}</div>
   <a href="{{ item.bookmark.url }}">{{ item.bookmark.title }}</a>
   <section class="tags">
@@ -19,5 +19,5 @@
     {% when None %}
   {% endmatch %}
   <a target="htmz"
-     href="/edit?id={{- item.bookmark.id.id() -}}#bookmark-{{ item.bookmark.id.id() }}">edit</a>
+     href="/edit?id={{- item.bookmark.id -}}#bookmark-{{- item.bookmark.id -}}">edit</a>
 </article>


### PR DESCRIPTION
Here we do a few things:

- [x] Refactor ID representations to allow for missing IDs in deserialization of objects; that way, a "new bookmark" form and an existing "update bookmark" form can deserialize into the same object type
- [x] Add a creation form, ideally compatible with linkding's format (so we can reuse  their browser extension