### PR TITLE
Fix clippy complaints about the openapi client generator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,7 @@ web-sys = "0.3.69"
 askama = "0.12.1"
 askama_axum = "0.4.0"
 axum-test = "14.8.0"
+
+# From https://djc.github.io/askama/performance.html:
+[profile.dev.package.askama_derive]
+opt-level = 3

--- a/flake.nix
+++ b/flake.nix
@@ -126,7 +126,7 @@
                 package = pkgs.writeShellApplication {
                   name = "regenerate-openapi-client";
                   text = ''
-                    cargo run --features dev -- generate-openapi-spec --rust-client src/lz-openapi
+                    cargo run --features dev -- generate-openapi-spec rust-client src/lz-openapi
                     cargo fmt -p lz-openapi
                   '';
                 };

--- a/src/lz-cli/src/main.rs
+++ b/src/lz-cli/src/main.rs
@@ -109,8 +109,8 @@ enum Commands {
     Web(lz_web::Args),
 
     /// Writes the contents of the openapi.json file to stdout
-    #[clap(alias = "generate-openapi-spec")]
-    GenerateOpenApiSpec(lz_web::export_openapi::Args),
+    #[clap(subcommand, alias = "generate-openapi-spec")]
+    GenerateOpenApiSpec(lz_web::export_openapi::Command),
 }
 
 #[tokio::main]

--- a/src/lz-openapi/src/lib.rs
+++ b/src/lz-openapi/src/lib.rs
@@ -511,9 +511,7 @@ pub mod types {
     ///  "required": [
     ///    "created_at",
     ///    "id",
-    ///    "shared",
     ///    "title",
-    ///    "unread",
     ///    "url",
     ///    "user_id"
     ///  ],
@@ -617,11 +615,13 @@ pub mod types {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub notes: Option<String>,
         ///Whether other users can see the bookmark.
-        pub shared: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub shared: Option<bool>,
         ///Title that the user gave the bookmark.
         pub title: String,
         ///Whether the bookmark is "to read"
-        pub unread: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub unread: Option<bool>,
         ///URL that the bookmark points to.
         pub url: String,
         pub user_id: UserId,
@@ -1301,9 +1301,9 @@ pub mod types {
             id: Result<super::BookmarkId, String>,
             modified_at: Result<Option<chrono::DateTime<chrono::offset::Utc>>, String>,
             notes: Result<Option<String>, String>,
-            shared: Result<bool, String>,
+            shared: Result<Option<bool>, String>,
             title: Result<String, String>,
-            unread: Result<bool, String>,
+            unread: Result<Option<bool>, String>,
             url: Result<String, String>,
             user_id: Result<super::UserId, String>,
             website_description: Result<Option<String>, String>,
@@ -1318,9 +1318,9 @@ pub mod types {
                     id: Err("no value supplied for id".to_string()),
                     modified_at: Ok(Default::default()),
                     notes: Ok(Default::default()),
-                    shared: Err("no value supplied for shared".to_string()),
+                    shared: Ok(Default::default()),
                     title: Err("no value supplied for title".to_string()),
-                    unread: Err("no value supplied for unread".to_string()),
+                    unread: Ok(Default::default()),
                     url: Err("no value supplied for url".to_string()),
                     user_id: Err("no value supplied for user_id".to_string()),
                     website_description: Ok(Default::default()),
@@ -1391,7 +1391,7 @@ pub mod types {
             }
             pub fn shared<T>(mut self, value: T) -> Self
             where
-                T: std::convert::TryInto<bool>,
+                T: std::convert::TryInto<Option<bool>>,
                 T::Error: std::fmt::Display,
             {
                 self.shared = value
@@ -1411,7 +1411,7 @@ pub mod types {
             }
             pub fn unread<T>(mut self, value: T) -> Self
             where
-                T: std::convert::TryInto<bool>,
+                T: std::convert::TryInto<Option<bool>>,
                 T::Error: std::fmt::Display,
             {
                 self.unread = value

--- a/src/lz-web/Cargo.toml
+++ b/src/lz-web/Cargo.toml
@@ -49,7 +49,3 @@ askama = { workspace = true, features = ["with-axum", "serde"] }
 axum-test = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 testresult = { workspace = true }
-
-# From https://djc.github.io/askama/performance.html:
-[profile.dev.package.askama_derive]
-opt-level = 3

--- a/src/lz-web/src/export_openapi.rs
+++ b/src/lz-web/src/export_openapi.rs
@@ -1,53 +1,66 @@
 //! An exporter for the current openapi.json file
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
-use clap::Parser;
+use clap::Subcommand;
 #[cfg(feature = "dev")]
 use progenitor::{GenerationSettings, Generator, InterfaceStyle, TypePatch};
 use utoipa::OpenApi as _;
 
 use crate::api;
 
-#[derive(Clone, PartialEq, Eq, Debug, Parser)]
-pub struct Args {
-    #[cfg_attr(feature = "dev", clap(long))]
-    #[cfg(feature = "dev")]
-    rust_client: Option<PathBuf>,
-    #[clap(long)]
-    openapi_json: Option<PathBuf>,
+#[derive(Clone, PartialEq, Eq, Debug, Subcommand)]
+pub enum Command {
+    /// Generate the rust OpenAPI client for `lz-openapi`.
+    #[cfg_attr(not(feature = "dev"), clap(skip))]
+    RustClient { crate_root: PathBuf },
+    /// Generate the openapi.json spec file.
+    Json { out: PathBuf },
 }
 
-pub fn run(args: &Args) -> anyhow::Result<()> {
+pub fn run(args: &Command) -> anyhow::Result<()> {
     let json = api::ApiDoc::openapi().to_pretty_json()?;
-    if let Some(out) = &args.openapi_json {
-        std::fs::write(out, json).with_context(|| format!("writing {out:?}"))?;
-    }
-    #[cfg(feature = "dev")]
-    if let Some(dest_crate) = &args.rust_client {
-        let spec = serde_json::from_str(&json).unwrap();
-        let mut generator = Generator::new(
-            GenerationSettings::new()
-                .with_interface(InterfaceStyle::Builder)
-                // required by dioxus component props:
-                .with_derive("PartialEq")
-                // required for hashability:
-                .with_derive("Eq")
-                .with_derive("Hash")
-                // Patch Copy onto all ID types:
-                .with_patch("BookmarkId", TypePatch::default().with_derive("Copy"))
-                .with_patch("UserId", TypePatch::default().with_derive("Copy")),
-        );
-
-        let tokens = generator.generate_tokens(&spec).unwrap();
-        let ast = syn::parse2(tokens).unwrap();
-        let content = prettyplease::unparse(&ast);
-
-        let out_file = dest_crate.join("src/lib.rs").to_path_buf();
-
-        std::fs::write(&out_file, content)
-            .with_context(|| format!("writing rust client to {out_file:?}"))?;
+    match args {
+        Command::Json { out } => generate_json(out, &json)?,
+        Command::RustClient { crate_root } => generate_rust_client(crate_root, &json)?,
     }
     Ok(())
+}
+
+fn generate_json(out: &Path, json: &str) -> anyhow::Result<()> {
+    std::fs::write(out, json).with_context(|| format!("writing openapi JSON to {out:?}"))?;
+    Ok(())
+}
+
+#[cfg(feature = "dev")]
+fn generate_rust_client(crate_root: &Path, json: &str) -> anyhow::Result<()> {
+    let spec = serde_json::from_str(json).unwrap();
+    let mut generator = Generator::new(
+        GenerationSettings::new()
+            .with_interface(InterfaceStyle::Builder)
+            // required by dioxus component props:
+            .with_derive("PartialEq")
+            // required for hashability:
+            .with_derive("Eq")
+            .with_derive("Hash")
+            // Patch Copy onto all ID types:
+            .with_patch("BookmarkId", TypePatch::default().with_derive("Copy"))
+            .with_patch("UserId", TypePatch::default().with_derive("Copy")),
+    );
+
+    let tokens = generator.generate_tokens(&spec).unwrap();
+    let ast = syn::parse2(tokens).unwrap();
+    let content = prettyplease::unparse(&ast);
+
+    let out_file = crate_root.join("src/lib.rs").to_path_buf();
+
+    std::fs::write(&out_file, content)
+        .with_context(|| format!("writing rust client to {out_file:?}"))?;
+    Ok(())
+}
+
+#[cfg(not(feature = "dev"))]
+fn generate_rust_client(_out: &Path, _json: &str) -> anyhow::Result<()> {
+    anyhow::bail!("Not compiled with `--feature dev`, can not generate the necessary rust code.")
 }


### PR DESCRIPTION
Due to the difference in features used in CI tasks, the generator would complain or it wouldn't. This rewrites things such that the complaint will be unnecessary.

Also, re-generates the openapi client.