### PR TITLE
Fix testing in CI

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_toolchain: ["nightly","stable"]
-        cargo_test_args: [""]
+        rust_toolchain: ["nightly", "stable"]
+        cargo_test_args: ["--workspace"]
     with:
       rust_toolchain: ${{matrix.rust_toolchain}}
       cargo_test_args: ${{matrix.cargo_test_args}}

--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,7 @@
               pkgs.sqlx-cli
               pkgs.sqlite
               pkgs.cargo-watch
+              pkgs.cargo-nextest
               pkgs.cargo-udeps
               pkgs.nodejs_21
               pkgs.djlint

--- a/src/lz-import-linkding/src/schema.rs
+++ b/src/lz-import-linkding/src/schema.rs
@@ -82,11 +82,11 @@ pub(crate) struct Bookmark {
 }
 
 impl Bookmark {
-    pub fn as_lz_bookmark(&self) -> lz_db::Bookmark<(), ()> {
+    pub fn as_lz_bookmark(&self) -> lz_db::Bookmark<lz_db::NoId, lz_db::NoId> {
         let url = self.url.clone();
         let mut other = lz_db::Bookmark {
-            id: (),
-            user_id: (),
+            id: lz_db::NoId,
+            user_id: lz_db::NoId,
             url,
             created_at: Default::default(),
             modified_at: Default::default(),


### PR DESCRIPTION
Apparently we haven't been running tests in CI (because the nextest runner only runs for the "default packages", which here is the cli crate, which has no tests). This PR fixes that.