### PR TITLE
Adding `lz rm` subcommand

### DIFF
--- a/.sqlx/query-8c7498512311a6e76322ec1f6128567c3b969e541fc0a9d8a5fa63a1f93d0c4c.json
+++ b/.sqlx/query-8c7498512311a6e76322ec1f6128567c3b969e541fc0a9d8a5fa63a1f93d0c4c.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n               DELETE FROM bookmarks WHERE bookmark_id = ? AND user_id = ?;\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "8c7498512311a6e76322ec1f6128567c3b969e541fc0a9d8a5fa63a1f93d0c4c"
+}

--- a/src/lz-db/migrations/20240225141910_initial_schema.sql
+++ b/src/lz-db/migrations/20240225141910_initial_schema.sql
@@ -53,7 +53,7 @@ CREATE TABLE "bookmark_tags" (
   "tag_id" INTEGER NOT NULL,
 
   PRIMARY KEY ("bookmark_id","tag_id"),
-  FOREIGN KEY("bookmark_id") REFERENCES "bookmarks"("bookmark_id"),
+  FOREIGN KEY("bookmark_id") REFERENCES "bookmarks"("bookmark_id") ON DELETE CASCADE,
   FOREIGN KEY("tag_id") REFERENCES "tags"("tag_id")
 ) STRICT;
 
@@ -63,6 +63,6 @@ CREATE TABLE "bookmark_associations" (
   "context" TEXT,
 
   PRIMARY KEY ("bookmark_id","url_id"),
-  FOREIGN KEY ("bookmark_id") REFERENCES "bookmarks"("bookmark_id")
+  FOREIGN KEY ("bookmark_id") REFERENCES "bookmarks"("bookmark_id") ON DELETE CASCADE,
   FOREIGN KEY ("url_id") REFERENCES "urls"("url_id")
 ) STRICT;


### PR DESCRIPTION
This changeset provides a transaction method for deleting bookmarks (although not URLs, which are currently being preserved), and a `rm` subcommand for the CLI for applying same.